### PR TITLE
Razor plugin asset fix

### DIFF
--- a/src/NServiceKit.Common/Web/ContentType.cs
+++ b/src/NServiceKit.Common/Web/ContentType.cs
@@ -79,6 +79,9 @@ namespace NServiceKit.Common.Web
         /// <summary>The binary.</summary>
         public const string Binary = "application/octet-stream";
 
+        /// <summary>Css.</summary>
+        public const string css = "text/css";
+
         /// <summary>Gets endpoint attributes.</summary>
         ///
         /// <param name="contentType">The contentType to act on.</param>

--- a/src/NServiceKit.Razor/EmbeddedResourceRazorPlugin.cs
+++ b/src/NServiceKit.Razor/EmbeddedResourceRazorPlugin.cs
@@ -61,12 +61,9 @@ namespace NServiceKit.Razor
             {
                 foreach (string resource in asm.GetManifestResourceNames())
                 {
-                    if (resource.EndsWith(".cshtml", StringComparison.OrdinalIgnoreCase))
-                    {
                         // Get just the file name. Internally, ServiceStack dumps all these in a giant "/Views" directory anyway, so let's just do that.
                         string path = string.Join(".", resource.Split('.').Reverse().Take(2).Reverse());
                         viewsDir.AddFile(path, new StreamReader(asm.GetManifestResourceStream(resource)).ReadToEnd());
-                    }
                 }
             }
 

--- a/src/NServiceKit.Razor/Managers/RazorPageResolver.cs
+++ b/src/NServiceKit.Razor/Managers/RazorPageResolver.cs
@@ -11,14 +11,12 @@ using NServiceKit.ServiceHost;
 using NServiceKit.Text;
 using NServiceKit.WebHost.Endpoints.Extensions;
 using NServiceKit.WebHost.Endpoints.Support;
+using System.Web.UI.WebControls;
+using NServiceKit.IO;
+using NServiceKit.Text.Controller;
 
 namespace NServiceKit.Razor.Managers
 {
-    using System.Web.UI.WebControls;
-
-    using NServiceKit.IO;
-    using NServiceKit.Text.Controller;
-
     /// <summary>Renders the partial delegate.</summary>
     ///
     /// <param name="pageName">  Name of the page.</param>

--- a/src/NServiceKit.Razor/Managers/RazorPageResolver.cs
+++ b/src/NServiceKit.Razor/Managers/RazorPageResolver.cs
@@ -14,6 +14,11 @@ using NServiceKit.WebHost.Endpoints.Support;
 
 namespace NServiceKit.Razor.Managers
 {
+    using System.Web.UI.WebControls;
+
+    using NServiceKit.IO;
+    using NServiceKit.Text.Controller;
+
     /// <summary>Renders the partial delegate.</summary>
     ///
     /// <param name="pageName">  Name of the page.</param>
@@ -75,35 +80,40 @@ namespace NServiceKit.Razor.Managers
         {
             //does not have a .cshtml extension
             var ext = Path.GetExtension(pathInfo);
-            if (!string.IsNullOrEmpty(ext) && ext != config.RazorFileExtension)
-                return null;
-
-            //pathInfo on dir doesn't match existing razor page
-            if (string.IsNullOrEmpty(ext) && viewManager.GetPageByPathInfo(pathInfo) == null)
-                return null;
-
-            //if there is any denied predicates for the path, return nothing
-            if (this.config.Deny.Any(denined => denined(pathInfo))) return null;
-
-            //Redirect for /default.cshtml => / or /page.cshtml => /page
-            if (pathInfo.EndsWith(config.RazorFileExtension))
+            if (ext == config.RazorFileExtension)
             {
-                pathInfo = pathInfo.EndsWithIgnoreCase(config.DefaultPageName)
-                    ? pathInfo.Substring(0, pathInfo.Length - config.DefaultPageName.Length)
-                    : pathInfo.WithoutExtension();
+                //pathInfo on dir doesn't match existing razor page
+                if (string.IsNullOrEmpty(ext) && viewManager.GetPageByPathInfo(pathInfo) == null) return null;
 
-                var webHostUrl = config.WebHostUrl;
-                return new RedirectHttpHandler
+                //if there is any denied predicates for the path, return nothing
+                if (this.config.Deny.Any(denined => denined(pathInfo))) return null;
+
+                //Redirect for /default.cshtml => / or /page.cshtml => /page
+                if (pathInfo.EndsWith(config.RazorFileExtension))
                 {
-                    AbsoluteUrl = webHostUrl.IsNullOrEmpty()
-                        ? null
-                        : webHostUrl.CombineWith(pathInfo),
-                    RelativeUrl = webHostUrl.IsNullOrEmpty()
-                        ? pathInfo
-                        : null
-                };
-            }
+                    pathInfo = pathInfo.EndsWithIgnoreCase(config.DefaultPageName)
+                                   ? pathInfo.Substring(0, pathInfo.Length - config.DefaultPageName.Length)
+                                   : pathInfo.WithoutExtension();
 
+                    var webHostUrl = config.WebHostUrl;
+                    return new RedirectHttpHandler
+                               {
+                                   AbsoluteUrl =
+                                       webHostUrl.IsNullOrEmpty()
+                                           ? null
+                                           : webHostUrl.CombineWith(pathInfo),
+                                   RelativeUrl = webHostUrl.IsNullOrEmpty() ? pathInfo : null
+                               };
+                }
+            }
+            else
+            {
+                if (this.viewManager.GetVirutalFile(pathInfo) == null)
+                {
+                    return null;
+                }
+            }
+            
             //only return "this" when we can, indeed, handle the httpReq.
             return this;
         }
@@ -113,9 +123,20 @@ namespace NServiceKit.Razor.Managers
         /// </summary>
         public override void ProcessRequest(IHttpRequest httpReq, IHttpResponse httpRes, string operationName)
         {
-            httpRes.ContentType = ContentType.Html;
+            ////ToDo: Figure out binary assets like jpgs and pngs. 
 
-            ResolveAndExecuteRazorPage(httpReq, httpRes, null);
+            httpRes.ContentType = ContentType.PlainText;
+
+            if (httpReq.PathInfo.EndsWith("js"))
+            {
+                httpRes.ContentType = ContentType.JavaScript;
+            }
+            else if (httpReq.PathInfo.EndsWith("css"))
+            {
+                httpRes.ContentType = ContentType.css;
+            }
+
+            this.ResolveRazorPageAsset(httpReq, httpRes, null);
             httpRes.EndRequest(skipHeaders: true);
         }
 
@@ -154,6 +175,14 @@ namespace NServiceKit.Razor.Managers
             var razorPage = this.viewManager.GetPageByName(httpReq.OperationName) //Request DTO
                          ?? this.viewManager.GetPage(httpReq, model); // Response DTO
             return razorPage;
+        }
+
+
+        private IVirtualFile FindRazorPageAsset(IHttpRequest httpReq, object model)
+        {
+            var viewName = httpReq.PathInfo; 
+
+            return this.viewManager.GetVirutalFile(viewName);  ////, httpReq, model);
         }
 
         /// <summary>Resolve and execute razor page.</summary>
@@ -196,6 +225,25 @@ namespace NServiceKit.Razor.Managers
                 page.WriteTo(writer);
             }
             return page;
+        }
+
+        private IVirtualFile ResolveRazorPageAsset(IHttpRequest httpReq, IHttpResponse httpRes, object model)
+        {
+            IVirtualFile razerPageAsset = this.FindRazorPageAsset(httpReq, model);
+
+            if (razerPageAsset == null)
+            {
+                httpRes.StatusCode = (int)HttpStatusCode.NotFound;
+                return null;
+            }
+
+            using (var writer = new StreamWriter(httpRes.OutputStream, UTF8EncodingWithoutBom))
+            {
+                writer.Write(razerPageAsset.ReadAllText());
+            }
+
+
+            return razerPageAsset;
         }
 
         private Tuple<IRazorView, string> ExecuteRazorPageWithLayout(IHttpRequest httpReq, IHttpResponse httpRes, object model, IRazorView page, Func<string> layout)

--- a/src/NServiceKit.Razor/Managers/RazorViewManager.cs
+++ b/src/NServiceKit.Razor/Managers/RazorViewManager.cs
@@ -438,7 +438,9 @@ namespace NServiceKit.Razor.Managers
         public virtual IVirtualFile GetVirutalFile(string ospath)
         {
             var relative = GetRelativePath(ospath);
-            return this.PathProvider.GetFile(relative);
+            var file = this.PathProvider.GetFile(relative);
+
+            return file; 
         }
         #endregion
     }

--- a/src/NServiceKit/VirtualPath/InMemoryVirtualPathProvider.cs
+++ b/src/NServiceKit/VirtualPath/InMemoryVirtualPathProvider.cs
@@ -191,8 +191,16 @@ namespace NServiceKit.VirtualPath
         /// <returns></returns>
         public override IVirtualFile GetFile(string virtualPath)
         {
-            virtualPath = StripBeginningDirectorySeparator(virtualPath);
-            return files.FirstOrDefault(x => x.FilePath == virtualPath);
+            string filename = Path.GetFileName(virtualPath); 
+
+            // Actually looks for files now. 
+            foreach(IVirtualDirectory fileDir in this.Directory.Directories)
+            {
+                IVirtualFile returnFile = fileDir.Files.First(x => x.Name == filename); 
+                return returnFile; 
+            }
+
+            return null; 
         }
 
         /// <summary>


### PR DESCRIPTION
This band aids a big issue with razor. 

1. Now loads files other the .cshtml. Like JS and CSS. 
2. Actually retrieves and returns requested files from the virtual directory. 
 
It still however does not retrieve binary assets such as jpgs or pngs. 