### PR TITLE
HttpRequestContext finalizer was causing a memory leak.

### DIFF
--- a/src/NServiceKit/ServiceHost/HttpRequestContext.cs
+++ b/src/NServiceKit/ServiceHost/HttpRequestContext.cs
@@ -257,15 +257,6 @@ namespace NServiceKit.ServiceHost
 				: null;
 		}
 
-        /// <summary>Finalizes an instance of the NServiceKit.ServiceHost.HttpRequestContext class.</summary>
-		~HttpRequestContext()
-		{
-			if (this.AutoDispose)
-			{
-				Dispose(false);
-			}
-		}
-
         /// <summary>Releases the unmanaged resources used by the NServiceKit.ServiceHost.HttpRequestContext and optionally releases the managed resources.</summary>
 		public void Dispose()
 		{


### PR DESCRIPTION
I was running a load test (using siege) against my web service and discovered that there appeared to be a memory leak. Once I ran a Memory Profiler I was able to track the leak down to instances of HttpRequestContext that were apparently not being cleaned up because their finalizers were not executing. From what I understand, finalizers are not guarenteed to execute, but having a finalizer will keep the object around when otherwise it could be released (http://ericlippert.com/2015/05/18/when-everything-you-know-is-wrong-part-one/). This change simply gets rid of the finalizer which seems to have fixed the memory leak.