### PR TITLE
Implemented case-insensitivity for URL content type suffixes.

### DIFF
--- a/src/NServiceKit.Common/Web/HttpResponseFilter.cs
+++ b/src/NServiceKit.Common/Web/HttpResponseFilter.cs
@@ -54,6 +54,10 @@ namespace NServiceKit.Common.Web
         /// <returns>The format content type.</returns>
         public string GetFormatContentType(string format)
         {
+            //Ensure format suffix is in lower case:
+            //XML, Json etc. should be acceptible
+            format = format.ToLowerInvariant();
+
             //built-in formats
             if (format == "json")
                 return ContentType.Json;


### PR DESCRIPTION
In order to support URL suffixes like .XML, .Json etc.
which was not possible to configure, I have added
format conversion to lower case before comparison
with reference values which all are in lower case.

Without this fix it was not possible to use content format configuration using non-lower case suffixes. All other URL parts (path, query) was easy to configure to be case-insensitive.