### PR TITLE
Fix for potential format loss while getting media type

### DIFF
--- a/src/NServiceKit.Common/Web/HttpResponseFilter.cs
+++ b/src/NServiceKit.Common/Web/HttpResponseFilter.cs
@@ -54,16 +54,15 @@ namespace NServiceKit.Common.Web
         /// <returns>The format content type.</returns>
         public string GetFormatContentType(string format)
         {
-            //Ensure format suffix is in lower case:
-            //XML, Json etc. should be acceptible
-            format = format.ToLowerInvariant();
+            if (format == null)
+                throw new ArgumentNullException("format");
 
             //built-in formats
-            if (format == "json")
+            if (format.Equals("json", StringComparison.OrdinalIgnoreCase))
                 return ContentType.Json;
-            if (format == "xml")
+            if (format.Equals("xml", StringComparison.OrdinalIgnoreCase))
                 return ContentType.Xml;
-            if (format == "jsv")
+            if (format.Equals("jsv", StringComparison.OrdinalIgnoreCase))
                 return ContentType.Jsv;
 
             string registeredFormats;

--- a/tests/NServiceKit.Common.Tests/NServiceKit.Common.Tests.csproj
+++ b/tests/NServiceKit.Common.Tests/NServiceKit.Common.Tests.csproj
@@ -198,6 +198,7 @@
     <Compile Include="Text\AdhocJsTests.cs" />
     <Compile Include="OAuth\OAuthUserSessionTestsBase.cs" />
     <Compile Include="UrlExtensionTests.cs" />
+    <Compile Include="Web\HttpResponseFilterTests.cs" />
     <Compile Include="Xlinq\XlinqExtensionsTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/NServiceKit.Common.Tests/Web/HttpResponseFilterTests.cs
+++ b/tests/NServiceKit.Common.Tests/Web/HttpResponseFilterTests.cs
@@ -1,4 +1,6 @@
-﻿using NServiceKit.Common.Web;
+﻿using System;
+
+using NServiceKit.Common.Web;
 
 using NUnit.Framework;
 
@@ -20,21 +22,21 @@ namespace NServiceKit.Common.Tests.Web
         }
 
         [Test]
-        public void GetFormatContentType_WhenFormatIsUppercaseJSON_ShouldReturnJsonMediaType()
-        {
-            // Arrange
-            // Act
-            // Assert
-            AssertThatGetFormatContentTypeReturnsMediaTypeForFormat("JSON", "application/json");
-        }
-
-        [Test]
         public void GetFormatContentType_WhenFormatIsMixedcaseJSON_ShouldReturnJsonMediaType()
         {
             // Arrange
             // Act
             // Assert
             AssertThatGetFormatContentTypeReturnsMediaTypeForFormat("JsOn", "application/json");
+        }
+
+        [Test]
+        public void GetFormatContentType_WhenFormatIsUppercaseJSON_ShouldReturnJsonMediaType()
+        {
+            // Arrange
+            // Act
+            // Assert
+            AssertThatGetFormatContentTypeReturnsMediaTypeForFormat("JSON", "application/json");
         }
 
         [Test]
@@ -91,6 +93,69 @@ namespace NServiceKit.Common.Tests.Web
             AssertThatGetFormatContentTypeReturnsMediaTypeForFormat("JSV", "application/jsv");
         }
 
+        [Test]
+        public void GetFormatContentType_WhenFormatIsInLowercaseAndRegistered_ShouldReturnRegisteredMediaType()
+        {
+            // Arrange
+            HttpResponseFilter responseFilter = new HttpResponseFilter();
+            responseFilter.ContentTypeFormats.Add("registered_format", "registeredMediaType");
+
+            // Act
+            string contentType = responseFilter.GetFormatContentType("registered_format");
+
+            // Assert
+            Assert.That(contentType, Is.EqualTo("registeredMediaType"));
+        }
+
+        [Test]
+        public void GetFormatContentType_WhenFormatIsInUppercaseAndRegistered_ShouldReturnRegisteredMediaType()
+        {
+            // Arrange
+            HttpResponseFilter responseFilter = new HttpResponseFilter();
+            responseFilter.ContentTypeFormats.Add("REGISTERED_FORMAT", "registeredMediaType");
+
+            // Act
+            string contentType = responseFilter.GetFormatContentType("REGISTERED_FORMAT");
+
+            // Assert
+            Assert.That(contentType, Is.EqualTo("registeredMediaType"));
+        }
+
+        [Test]
+        public void GetFormatContentType_WhenFormatIsUnregistered_ShouldReturnNull()
+        {
+            // Arrange
+            // Act
+            // Assert
+            AssertThatGetFormatContentTypeReturnsNullForFormat("unregisteredFormat");
+        }
+
+        [Test]
+        public void GetFormatContentType_WhenFormatIsEmpty_ShouldReturnNull()
+        {
+            // Arrange
+            string emptyFormat = string.Empty;
+
+            // Act
+            // Assert
+            AssertThatGetFormatContentTypeReturnsNullForFormat(emptyFormat);
+        }
+
+        [Test]
+        public void GetFormatContentType_WhenFormatIsNull_ShouldThrowArgumentNullException()
+        {
+            // Arrange
+            HttpResponseFilter responseFilter = new HttpResponseFilter();
+
+            string nullFormat = null;
+
+            // Act
+            TestDelegate getFormatContentTypeAction = () => responseFilter.GetFormatContentType(nullFormat);
+
+            // Assert
+            Assert.Throws<ArgumentNullException>(getFormatContentTypeAction);
+        }
+
         private void AssertThatGetFormatContentTypeReturnsMediaTypeForFormat(string format, string expectedMediaType)
         {
             // Arrange
@@ -101,6 +166,18 @@ namespace NServiceKit.Common.Tests.Web
 
             // Assert
             Assert.That(contentType, Is.EqualTo(expectedMediaType));
+        }
+
+        private void AssertThatGetFormatContentTypeReturnsNullForFormat(string format)
+        {
+            // Arrange
+            HttpResponseFilter responseFilter = new HttpResponseFilter();
+
+            // Act
+            string contentType = responseFilter.GetFormatContentType(format);
+
+            // Assert
+            Assert.That(contentType, Is.Null);
         }
     }
 }

--- a/tests/NServiceKit.Common.Tests/Web/HttpResponseFilterTests.cs
+++ b/tests/NServiceKit.Common.Tests/Web/HttpResponseFilterTests.cs
@@ -1,0 +1,106 @@
+﻿using NServiceKit.Common.Web;
+
+using NUnit.Framework;
+
+namespace NServiceKit.Common.Tests.Web
+{
+    /// <summary>
+    ///     Unit tests for <see cref="HttpResponseFilter" />.
+    /// </summary>
+    [TestFixture]
+    public class HttpResponseFilterTests
+    {
+        [Test]
+        public void GetFormatContentType_WhenFormatIsLowercaseJSON_ShouldReturnJsonMediaType()
+        {
+            // Arrange
+            // Act
+            // Assert
+            AssertThatGetFormatContentTypeReturnsMediaTypeForFormat("json", "application/json");
+        }
+
+        [Test]
+        public void GetFormatContentType_WhenFormatIsUppercaseJSON_ShouldReturnJsonMediaType()
+        {
+            // Arrange
+            // Act
+            // Assert
+            AssertThatGetFormatContentTypeReturnsMediaTypeForFormat("JSON", "application/json");
+        }
+
+        [Test]
+        public void GetFormatContentType_WhenFormatIsMixedcaseJSON_ShouldReturnJsonMediaType()
+        {
+            // Arrange
+            // Act
+            // Assert
+            AssertThatGetFormatContentTypeReturnsMediaTypeForFormat("JsOn", "application/json");
+        }
+
+        [Test]
+        public void GetFormatContentType_WhenFormatIsLowercaseXML_ShouldReturnXMLMediaType()
+        {
+            // Arrange
+            // Act
+            // Assert
+            AssertThatGetFormatContentTypeReturnsMediaTypeForFormat("xml", "application/xml");
+        }
+
+        [Test]
+        public void GetFormatContentType_WhenFormatIsMixedcaseXML_ShouldReturnXMLMediaType()
+        {
+            // Arrange
+            // Act
+            // Assert
+            AssertThatGetFormatContentTypeReturnsMediaTypeForFormat("XmL", "application/xml");
+        }
+
+        [Test]
+        public void GetFormatContentType_WhenFormatIsUppercaseXML_ShouldReturnXMLMediaType()
+        {
+            // Arrange
+            // Act
+            // Assert
+            AssertThatGetFormatContentTypeReturnsMediaTypeForFormat("XML", "application/xml");
+        }
+
+        [Test]
+        public void GetFormatContentType_WhenFormatIsLowercaseJSV_ShouldReturnJSVMediaType()
+        {
+            // Arrange
+            // Act
+            // Assert
+            AssertThatGetFormatContentTypeReturnsMediaTypeForFormat("jsv", "application/jsv");
+        }
+
+        [Test]
+        public void GetFormatContentType_WhenFormatIsMixedcaseJSV_ShouldReturnJSVMediaType()
+        {
+            // Arrange
+            // Act
+            // Assert
+            AssertThatGetFormatContentTypeReturnsMediaTypeForFormat("JsV", "application/jsv");
+        }
+
+        [Test]
+        public void GetFormatContentType_WhenFormatIsUppercaseJSV_ShouldReturnJSVMediaType()
+        {
+            // Arrange
+            // Act
+            // Assert
+            AssertThatGetFormatContentTypeReturnsMediaTypeForFormat("JSV", "application/jsv");
+        }
+
+        private void AssertThatGetFormatContentTypeReturnsMediaTypeForFormat(string format, string expectedMediaType)
+        {
+            // Arrange
+            HttpResponseFilter responseFilter = new HttpResponseFilter();
+
+            // Act
+            string contentType = responseFilter.GetFormatContentType(format);
+
+            // Assert
+            Assert.That(contentType, Is.EqualTo(expectedMediaType));
+        }
+    }
+}


### PR DESCRIPTION
While writing unit tests fro HttpResponseFilter noticed that if I register a format in non-lower case, then it can't be found with the call to GetFormatContentType().

Not using ToLowerInvariant should be more memory efficient as well
